### PR TITLE
OPT: check element first to avoid unnecessary executing in walkTree function

### DIFF
--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -57,12 +57,12 @@ export function walkTree(
   ) => boolean | void,
   newContext: Map<any, any> = new Map(),
 ) {
-  if (Array.isArray(element)) {
-    element.forEach(item => walkTree(item, context, visitor, newContext));
+  if (!element) {
     return;
   }
-
-  if (!element) {
+                       
+  if (Array.isArray(element)) {
+    element.forEach(item => walkTree(item, context, visitor, newContext));
     return;
   }
 


### PR DESCRIPTION
run `if (!element)` at first to avoid rest code running. 
If `if (!element)` equals true, then stop executing the rest other wise we run  `element.forEach(item => walkTree(item, context, visitor, newContext));` all the time at first

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->